### PR TITLE
Changed scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.25</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.codahale.metrics</groupId>


### PR DESCRIPTION
Mark the SLF4J dependency as *provided* so it is not included in the generated jar file.